### PR TITLE
fix seeding for locations & events

### DIFF
--- a/db/migrate/20140223080847_create_locations.rb
+++ b/db/migrate/20140223080847_create_locations.rb
@@ -2,13 +2,13 @@ class CreateLocations < ActiveRecord::Migration
   def change
     create_table :locations do |t|
       t.string :name
-			t.text :description
-			t.string :address1
-			t.string :address2
-			t.string :city
-			t.string :state_abbrv
-			t.integer :zipcode
-
+      t.text :description
+      t.string :address1
+      t.string :address2
+      t.string :city
+      t.string :state_abbrv
+      t.integer :zipcode
+      
       t.timestamps
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,6 +30,7 @@ count.times do
     city: Faker::Address.ypreg_city,
     state_abbrv: Faker::Address.state_abbr,
     zipcode: Faker::Address.zip_code,
+    location_type: 'camp',
     max_capacity: rand(50..200).round(-1)
   )
   print '.'


### PR DESCRIPTION
The location objects being created were missing `location_type`. Fixes #19 