### PR TITLE
skip confirmation for user in rake create_admin task

### DIFF
--- a/lib/tasks/create_admin.rake
+++ b/lib/tasks/create_admin.rake
@@ -85,7 +85,7 @@ namespace :ypreg do
       print '> '
 
       input = STDIN.gets.chomp
-      print_colored_text("Let's try again; please enter your gender ('M'or 'F'): ", warning_text_color) unless input.size > 0 && %w(m f).include?(input.to_s)
+      print_colored_text("Let's try again; please enter your gender ('M'or 'F'): ", warning_text_color) unless input.size > 0 && %w(M m F f).include?(input.to_s)
     end
     user['gender'] = input.downcase == 'm' ? 'B': 'S'
 
@@ -147,6 +147,7 @@ namespace :ypreg do
           password: user['password'],
           role: 'admin',
           locality_id: locality['locality_id'])
+      new_user.skip_confirmation!
       if new_user.save
         notice = "\n#{new_user.name} (#{new_user.email}) created successfully."
         print_colored_text(notice, success_text_color)


### PR DESCRIPTION
Seems like we would want to skip confirmation for the create admin rake task. Makes sense for dev at least.